### PR TITLE
feat(mergesort): baseline + reuse buffer + cutoff + tests

### DIFF
--- a/src/main/java/org/example/algorithms/sort/MergeSort.java
+++ b/src/main/java/org/example/algorithms/sort/MergeSort.java
@@ -1,0 +1,90 @@
+package org.example.algorithms.sort;
+
+import org.example.metrics.ComparisonCounter;
+import org.example.metrics.MoveCounter;
+import org.example.metrics.RecursionDepthTracker;
+
+public class MergeSort {
+    private final int cutoff;
+    private final ComparisonCounter comps;
+    private final MoveCounter moves;
+    private final RecursionDepthTracker depth;
+
+    public MergeSort(int cutoff,
+                     ComparisonCounter comps,
+                     MoveCounter moves,
+                     RecursionDepthTracker depth) {
+        this.cutoff = cutoff;
+        this.comps = comps;
+        this.moves = moves;
+        this.depth = depth;
+    }
+
+    public void sort(int[] arr) {
+        int[] aux = new int[arr.length]; // единый буфер
+        sort(arr, aux, 0, arr.length - 1);
+    }
+
+    private void sort(int[] arr, int[] aux, int lo, int hi) {
+        if (hi - lo + 1 <= cutoff) {
+            insertionSort(arr, lo, hi);
+            return;
+        }
+
+        depth.enter();
+
+        int mid = lo + (hi - lo) / 2;
+        sort(arr, aux, lo, mid);
+        sort(arr, aux, mid + 1, hi);
+
+        merge(arr, aux, lo, mid, hi);
+
+        depth.exit();
+    }
+
+    private void merge(int[] arr, int[] aux, int lo, int mid, int hi) {
+        for (int k = lo; k <= hi; k++) {
+            aux[k] = arr[k];
+            moves.increment();
+        }
+
+        int i = lo, j = mid + 1;
+        for (int k = lo; k <= hi; k++) {
+            if (i > mid) {
+                arr[k] = aux[j++];
+                moves.increment();
+            } else if (j > hi) {
+                arr[k] = aux[i++];
+                moves.increment();
+            } else {
+                comps.increment();
+                if (aux[j] < aux[i]) {
+                    arr[k] = aux[j++];
+                    moves.increment();
+                } else {
+                    arr[k] = aux[i++];
+                    moves.increment();
+                }
+            }
+        }
+    }
+
+    private void insertionSort(int[] arr, int lo, int hi) {
+        for (int i = lo + 1; i <= hi; i++) {
+            int key = arr[i];
+            int j = i - 1;
+            while (j >= lo) {
+                comps.increment();
+                if (arr[j] > key) {
+                    arr[j + 1] = arr[j];
+                    moves.increment();
+                    j--;
+                } else {
+                    break;
+                }
+            }
+            arr[j + 1] = key;
+            moves.increment();
+        }
+    }
+}

--- a/src/test/java/org/example/algorithms/sort/MergeSortTest.java
+++ b/src/test/java/org/example/algorithms/sort/MergeSortTest.java
@@ -1,0 +1,24 @@
+package org.example.algorithms.sort;
+
+import org.example.metrics.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MergeSortTest {
+    @Test
+    void testMergeSortCorrectness() {
+        int[] arr = {5, 2, 9, 1, 5, 6};
+        ComparisonCounter comps = new ComparisonCounter();
+        MoveCounter moves = new MoveCounter();
+        RecursionDepthTracker depth = new RecursionDepthTracker();
+
+        MergeSort sorter = new MergeSort(5, comps, moves, depth);
+        sorter.sort(arr);
+
+        assertArrayEquals(new int[]{1, 2, 5, 5, 6, 9}, arr);
+        assertTrue(comps.get() > 0);
+        assertTrue(moves.get() > 0);
+        assertTrue(depth.getMax() > 0);
+    }
+}


### PR DESCRIPTION
This PR adds a MergeSort implementation as part of Assignment 1 commit storyline.

Changes include:
- Classical Divide & Conquer implementation of MergeSort
- Linear-time merge with reusable buffer across recursion
- Cutoff to InsertionSort for small subarrays
- Integrated metrics (comparisons, moves, recursion depth)
- Unit tests to validate correctness and metric collection

Verified with JUnit5 tests
Metrics counters increment properly
Ready to merge into main
