### PR TITLE
feat(select): deterministic select (MoM5) + tests

### DIFF
--- a/src/main/java/org/example/algorithms/select/DeterministicSelect.java
+++ b/src/main/java/org/example/algorithms/select/DeterministicSelect.java
@@ -1,0 +1,63 @@
+package org.example.algorithms.select;
+
+import org.example.metrics.*;
+import org.example.algorithms.util.ArrayUtil;
+
+import java.util.Arrays;
+
+public class DeterministicSelect {
+    private final ComparisonCounter comps;
+    private final MoveCounter moves;
+    private final RecursionDepthTracker depth;
+
+    public DeterministicSelect(ComparisonCounter comps,
+                               MoveCounter moves,
+                               RecursionDepthTracker depth) {
+        this.comps = comps;
+        this.moves = moves;
+        this.depth = depth;
+    }
+
+    public int select(int[] arr, int k) {
+        if (k < 0 || k >= arr.length)
+            throw new IllegalArgumentException("k is out of bounds");
+        depth.enter();
+        int result = select(arr, 0, arr.length - 1, k);
+        depth.exit();
+        return result;
+    }
+
+    private int select(int[] arr, int lo, int hi, int k) {
+        if (lo == hi) return arr[lo];
+
+        int pivotIndex = median(arr, lo, hi);
+        int pivotNewIndex = ArrayUtil.partition(arr, lo, hi, pivotIndex, comps, moves);
+
+        if (k == pivotNewIndex) {
+            return arr[k];
+        } else if (k < pivotNewIndex) {
+            return select(arr, lo, pivotNewIndex - 1, k);
+        } else {
+            return select(arr, pivotNewIndex + 1, hi, k);
+        }
+    }
+
+    private int median(int[] arr, int lo, int hi) {
+        int n = hi - lo + 1;
+        if (n <= 5) {
+            Arrays.sort(arr, lo, hi + 1);
+            moves.add(n * (n - 1)); // грубая оценка
+            return lo + n / 2;
+        }
+
+        int numMedians = (int) Math.ceil((double) n / 5);
+        for (int i = 0; i < numMedians; i++) {
+            int subLo = lo + i * 5;
+            int subHi = Math.min(subLo + 4, hi);
+            Arrays.sort(arr, subLo, subHi + 1);
+            int medianIndex = subLo + (subHi - subLo) / 2;
+            ArrayUtil.swap(arr, lo + i, medianIndex, moves);
+        }
+        return median(arr, lo, lo + numMedians - 1);
+    }
+}

--- a/src/test/java/org/example/algorithms/select/DeterministicSelectTest.java
+++ b/src/test/java/org/example/algorithms/select/DeterministicSelectTest.java
@@ -1,0 +1,51 @@
+package org.example.algorithms.select;
+
+import org.example.metrics.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Random;
+
+class DeterministicSelectTest {
+    @Test
+    void testSmallArray() {
+        int[] arr = {5, 8, 6, 4, 2};
+        ComparisonCounter comps = new ComparisonCounter();
+        MoveCounter moves = new MoveCounter();
+        RecursionDepthTracker depth = new RecursionDepthTracker();
+
+        DeterministicSelect select = new DeterministicSelect(comps, moves, depth);
+        int result = select.select(arr, 2); // 3-й элемент по порядку (0-based)
+        assertEquals(4, result);
+    }
+
+    @Test
+    void testLargeArray() {
+        int n = 1000;
+        int[] arr = new Random().ints(n, 0, 10000).toArray();
+        int[] sorted = Arrays.copyOf(arr, arr.length);
+        Arrays.sort(sorted);
+
+        ComparisonCounter comps = new ComparisonCounter();
+        MoveCounter moves = new MoveCounter();
+        RecursionDepthTracker depth = new RecursionDepthTracker();
+
+        DeterministicSelect select = new DeterministicSelect(comps, moves, depth);
+
+        for (int k = 0; k < 10; k++) {
+            int result = select.select(Arrays.copyOf(arr, arr.length), k);
+            assertEquals(sorted[k], result);
+        }
+    }
+
+    @Test
+    void testOutOfBounds() {
+        DeterministicSelect select = new DeterministicSelect(
+                new ComparisonCounter(), new MoveCounter(), new RecursionDepthTracker()
+        );
+        int[] arr = {1, 2, 3};
+        assertThrows(IllegalArgumentException.class, () -> select.select(arr, -1));
+        assertThrows(IllegalArgumentException.class, () -> select.select(arr, 5));
+    }
+}


### PR DESCRIPTION
This PR introduces deterministic selection using Median-of-Medians (MoM5).

Changes:
- Implemented k-th order statistic with guaranteed O(n) worst-case
- Median-of-Medians pivot selection with groups of 5
- Reused ArrayUtil partition and swap
- Integrated metrics (comparisons, moves, recursion depth)
- Unit tests for small and large arrays, including edge cases

Verified with JUnit5
Correctness matches sorted array results
Handles out-of-bounds with exceptions
